### PR TITLE
Fix linewidth of filled display_draw_rectangle

### DIFF
--- a/display.c
+++ b/display.c
@@ -137,7 +137,7 @@ void display_draw_rectangle(uint16_t x_start, uint16_t y_start, uint16_t x_end, 
     uint16_t y_point;
     if (filled) {
         for (y_point = y_start; y_point < y_end; y_point++) {
-            display_draw_line(x_start, y_point, x_end, y_point, color, line_weight);
+            display_draw_line(x_start, y_point, x_end, y_point, color, 1);
         }
     } else {
         display_draw_line(x_start, y_start, x_end, y_start, color, line_weight);


### PR DESCRIPTION
This should be line width of 1 I think?  It is drawing a filled rectangle line by line.  

Without this fix I passed in 0 to the width because I only wanted a filled rectangle, so I thought the border width would not apply, but then it doesn't draw anything...